### PR TITLE
Changed 'read_nonblock' calls to 'read' calls

### DIFF
--- a/lib/px4_log_reader/log_file.rb
+++ b/lib/px4_log_reader/log_file.rb
@@ -34,8 +34,9 @@ module Px4LogReader
 
 	module LogFile
 
-		HEADER_MARKER = [0xA3,0x95]
-		HEADER_LENGTH = HEADER_MARKER.length + 1
+		HEADER_MARKER = [0xA3,0x95].freeze
+		HEADER_MESSAGE_TYPE_LENGTH = 1
+		HEADER_LENGTH = HEADER_MARKER.length + HEADER_MESSAGE_TYPE_LENGTH
 		FORMAT_DESCRIPTOR_TABLE = { FORMAT_MESSAGE.type => FORMAT_MESSAGE }.freeze
 
 		@@debug = false
@@ -152,19 +153,19 @@ module Px4LogReader
 
 			begin
 
-				data   = file.read_nonblock( HEADER_MARKER.length )
+				data   = file.read( HEADER_MARKER.length )
 				offset = file.pos
 
 				if data && ( data.length == HEADER_MARKER.length )
 
 					while !data.empty? && message_type.nil? do
 
-						if ( byte = file.read_nonblock( 1 ) )
+						if ( byte = file.read( HEADER_MESSAGE_TYPE_LENGTH ) )
 							data << byte
 						end
 						offset = file.pos
 
-						if data.length >= ( HEADER_MARKER.length + 1 )
+						if data.length >= HEADER_LENGTH
 
 							unpacked_data = data.unpack('C*')
 							

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -115,7 +115,6 @@ class TestReader < MiniTest::Test
 
 			reader.each_message do |message|
 
-				# puts "#{index+1}: #{message.descriptor.name}, #{'%02X'%message.descriptor.type}"
 				break if index >= expected_messages.size
 
 				expected_name = expected_messages[ index ][0]


### PR DESCRIPTION
All 'read_nonblock' calls have been changed to 'read' calls to avoid BadDescriptor exceptions on EOF on Windows. Currently, there is no advantage to using 'read_nonblock' over 'read'.