### PR TITLE
Close log file on exit of user read block

### DIFF
--- a/lib/px4_log_reader/reader.rb
+++ b/lib/px4_log_reader/reader.rb
@@ -32,44 +32,28 @@
 
 module Px4LogReader	
 
-	# Attach a reader to an existing input stream.
 	#
-	# @param input_stream [IO] Valid input stream
-	# @param options [Hash] Reader options hash
-	# @param block  Optional block
+	# Open the specified file for reading. The mandatory block is passed a
+	# Reader instance.
 	#
-	def self.attach( input_stream, options, &block )
+	# @param  filename [String]  Log file path
+	# @param  options  [Hash] Reader options hash
+	# @param  block  Required block
+	#
+	def self.open( filename, options = {}, &block )
 
-		reader = Reader.new( input_stream, options )
-
-		yield reader if block_given?
-
-		return reader
-		
-	end
-
-	def self.open( filename, options = {}, &block  )
-
-		reader = nil
+		unless block_given?
+			raise ArgumentError.new( 'Missing block' )
+		end
 
 		if File.exist?( filename )
-			reader = self.attach( File.open( filename, 'rb' ), options, &block )
-		end	
-
-		return reader
-
-	end
-
-	def self.open!( filename, options = {}, &block )
-		reader = nil
-
-		if File.exist?( filename )
-			reader = self.attach( File.open( filename, 'rb' ), options, &block )
+			File.open( filename, 'rb' ) do |file|
+				yield Reader.new( file, options )
+			end
 		else
 			raise FileNotFoundError.new( filename )
-		end	
-
-		return reader
+		end
+		
 	end
 
 	# Container to hold the most recent copy of each message type

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -43,24 +43,17 @@ class TestReader < MiniTest::Test
 		nonexistent_filename = 'nonexistent_logfile.px4log'
 
 		exception = assert_raises Px4LogReader::FileNotFoundError do
-			reader = Px4LogReader.open!( nonexistent_filename )
-		end
-
-		exception = assert_raises Px4LogReader::FileNotFoundError do
-			Px4LogReader.open!( nonexistent_filename ) do |reader|
+			Px4LogReader.open( nonexistent_filename ) do |reader|
 			end
 		end
 
 	end
 
-	def test_non_existent_log_file_no_except
-
+	def test_missing_block
 		nonexistent_filename = 'nonexistent_logfile.px4log'
 
-		assert_nil Px4LogReader.open( nonexistent_filename )
-
-		Px4LogReader.open( nonexistent_filename ) do |reader|
-			assert_nil reader
+		exception = assert_raises ArgumentError do
+			Px4LogReader.open( nonexistent_filename )
 		end
 	end
 


### PR DESCRIPTION
The Px4LogReader interface for opening a log file has been simplified to a single method. The method requires a block and automatically closes the log file once the block returns.